### PR TITLE
Propagate XFF and X-Real-IP from a list of CIDRs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+# 4 space indentation
+indent_style = space
+indent_size = 4
+
+# Character set
+charset = utf-8
+
+# Remove trailing whitespace
+trim_trailing_whitespace = true
+
+# Ensure files end with a newline
+insert_final_newline = true
+
+# Line endings (adjust based on your OS/team preference)
+# For Windows or cross-platform projects:
+# end_of_line = crlf
+# For Linux/macOS:
+end_of_line = lf

--- a/.editorconfig
+++ b/.editorconfig
@@ -22,3 +22,11 @@ insert_final_newline = true
 # end_of_line = crlf
 # For Linux/macOS:
 end_of_line = lf
+
+# Go files use tabs per gofmt standard
+[*.go]
+indent_style = tab
+
+# Makefiles require tabs
+[Makefile]
+indent_style = tab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: stable
   GOLANGCI_LINT_VERSION: v2.8
 
 jobs:
@@ -39,7 +38,6 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
           go-version-file: go.mod
 
       - name: Download dependencies
@@ -73,7 +71,6 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
           go-version-file: go.mod
 
       - name: Run golangci-lint
@@ -95,7 +92,6 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: ${{ env.GO_VERSION }}
           go-version-file: go.mod
 
       - name: Run go vet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          version: v2
           args: --timeout=5m
 
   vet:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ on:
 
 env:
   GO_VERSION: stable
-  GOLANGCI_LINT_VERSION: v2.6
+  GOLANGCI_LINT_VERSION: v2.8
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ on:
       - '.github/workflows/ci.yml'
   workflow_dispatch:
 
+env:
+  GO_VERSION: stable
+  GOLANGCI_LINT_VERSION: v2.6
+
 jobs:
   test:
     name: Run Tests
@@ -30,11 +34,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
+          go-version: ${{ env.GO_VERSION }}
           go-version-file: go.mod
 
       - name: Download dependencies
@@ -63,17 +68,18 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
+          go-version: ${{ env.GO_VERSION }}
           go-version-file: go.mod
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: latest
+          version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --timeout=5m
 
   vet:
@@ -84,11 +90,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
+          go-version: ${{ env.GO_VERSION }}
           go-version-file: go.mod
 
       - name: Run go vet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,9 @@ jobs:
           go-version-file: go.mod
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v2
+          version: latest
           args: --timeout=5m
 
   vet:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,11 +95,35 @@ jobs:
           go-version-file: go.mod
 
       - name: Run go vet
-        run: go vet ./...
+        run: make vet
+
+  fmt:
+    name: Format Check
+    runs-on: ubuntu-latest, fmt
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Check formatting
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "::error::The following files need formatting:"
+            echo "$unformatted"
+            exit 1
+          fi
 
   summary:
     name: CI Summary
-    needs: [test, lint, vet]
+    needs: [test, lint, vet, fmt]
     runs-on: ubuntu-latest
     if: always()
 
@@ -125,4 +149,10 @@ jobs:
             echo "- ✅ **Vet**: Passed" >> $GITHUB_STEP_SUMMARY
           else
             echo "- ❌ **Vet**: Failed" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          if [ "${{ needs.fmt.result }}" = "success" ]; then
+            echo "- ✅ **Format**: Passed" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- ❌ **Format**: Failed (run 'make fmt' to fix)" >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,125 @@
+name: CI - Test & Lint
+
+on:
+  push:
+    branches: [ main, master ]
+    paths:
+      - 'main.go'
+      - 'pkg/**'
+      - 'go.mod'
+      - 'go.sum'
+      - '.golangci.yaml'
+      - '.github/workflows/ci.yml'
+  pull_request:
+    branches: [ main, master ]
+    paths:
+      - 'main.go'
+      - 'pkg/**'
+      - 'go.mod'
+      - 'go.sum'
+      - '.golangci.yaml'
+      - '.github/workflows/ci.yml'
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run tests
+        run: go test -v -race -count=1 ./...
+
+      - name: Run tests with coverage
+        run: |
+          go test -coverprofile=coverage.out -covermode=atomic ./...
+          go tool cover -func=coverage.out
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.out
+          retention-days: 7
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          args: --timeout=5m
+
+  vet:
+    name: Vet
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run go vet
+        run: go vet ./...
+
+  summary:
+    name: CI Summary
+    needs: [test, lint, vet]
+    runs-on: ubuntu-latest
+    if: always()
+
+    steps:
+      - name: Create CI summary
+        run: |
+          echo "## 🧪 CI Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [ "${{ needs.test.result }}" = "success" ]; then
+            echo "- ✅ **Tests**: Passed" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- ❌ **Tests**: Failed" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          if [ "${{ needs.lint.result }}" = "success" ]; then
+            echo "- ✅ **Lint**: Passed" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- ❌ **Lint**: Failed" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          if [ "${{ needs.vet.result }}" = "success" ]; then
+            echo "- ✅ **Vet**: Passed" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- ❌ **Vet**: Failed" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,56 +1,64 @@
 version: "2"
-
 run:
-  timeout: 5m
   tests: true
-
 linters:
-  disable-all: true
+  default: none
   enable:
+    - bodyclose
+    - copyloopvar
+    - dogsled
+    - errcheck
+    - goconst
+    - gocritic
+    - goprintffuncname
+    - gosec
     - govet
     - ineffassign
-    - goconst
-    - gosec
-    - staticcheck
-    - unused
-    - bodyclose
-    - dogsled
-    - goprintffuncname
     - misspell
     - prealloc
-    - copyloopvar
-    - unconvert
-    - gocritic
     - revive
-    - errcheck
-
-linters-settings:
-  govet:
-    enable:
-      - shadow
-  revive:
+    - staticcheck
+    - unconvert
+    - unused
+  settings:
+    govet:
+      enable:
+        - shadow
+    revive:
+      rules:
+        - name: exported
+          arguments:
+            - disableStutteringCheck
+        - name: package-comments
+          disabled: true
+        - name: unused-parameter
+          disabled: true
+        - name: var-naming
+          disabled: true
+  exclusions:
+    generated: lax
     rules:
-      - name: exported
-        arguments:
-          - disableStutteringCheck
-      - name: package-comments
-        disabled: true
-      - name: unused-parameter
-        disabled: true
-      - name: var-naming
-        disabled: true
-
-issues:
-  exclude-use-default: false
-  exclude:
-    - "G104: Errors unhandled"
-  exclude-rules:
-    - text: "stutters"
-    - path: _test\.go
-      linters:
-        - revive
-        - bodyclose
-        - unconvert
-        - gocritic
-        - gosec
-        - goconst
+      - text: stutters
+        linters:
+          - revive
+      - linters:
+          - bodyclose
+          - goconst
+          - gocritic
+          - gosec
+          - revive
+          - unconvert
+        path: _test\.go
+      - path: (.+)\.go$
+        text: 'G104: Errors unhandled'
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,45 +1,17 @@
 version: "2"
-run:
-  deadline: 120s
-  # Default concurrency is a available CPU number
-  concurrency: 4
-  # Timeout for analysis, e.g. 30s, 5m, default is 1m
-  timeout: 5m
-  # Exit code when at least one issue was found, default is 1
-  issues-exit-code: 1
-  # Include test files or not, default is true
-  tests: true
-  # Default is true. Enables skipping of directories:
-  #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
-  skip-dirs-use-default: true
-  # Allow multiple parallel golangci-lint instances running.
-  # If false (default) - golangci-lint acquires file lock on start.
-  allow-parallel-runners: false
 
-# Output configuration options
-output:
-  # Format: colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions
-  format: colored-line-number
-  # Print lines of code with issue, default is true
-  print-issued-lines: true
-  # Print linter name in the end of issue text, default is true
-  print-linter-name: true
-  # Make issues output unique by line, default is true
-  uniq-by-line: true
-  # Add a prefix to the output file references, default is no prefix
-  path-prefix: ""
+run:
+  timeout: 5m
+  tests: true
 
 linters:
+  disable-all: true
   enable:
     - govet
     - ineffassign
     - goconst
-    # - gofmt
-    # - goimports
     - gosec
-    # - gosimple
     - staticcheck
-    # - typecheck
     - unused
     - bodyclose
     - dogsled
@@ -47,41 +19,38 @@ linters:
     - misspell
     - prealloc
     - copyloopvar
-    # - stylecheck
     - unconvert
     - gocritic
     - revive
-  disable-all: true
+    - errcheck
 
-# Linter settings
 linters-settings:
-  errcheck:
-    check-type-assertions: true
   govet:
-    check-shadowing: true
-  gofmt:
-    simplify: true
-  goimports:
-    local-prefixes: github.com/arulrajnet/basic-auth-proxy
+    enable:
+      - shadow
+  revive:
+    rules:
+      - name: exported
+        arguments:
+          - disableStutteringCheck
+      - name: package-comments
+        disabled: true
+      - name: unused-parameter
+        disabled: true
+      - name: var-naming
+        disabled: true
 
 issues:
+  exclude-use-default: false
+  exclude:
+    - "G104: Errors unhandled"
   exclude-rules:
+    - text: "stutters"
     - path: _test\.go
       linters:
-        - scopelint
+        - revive
         - bodyclose
         - unconvert
         - gocritic
         - gosec
         - goconst
-        - revive
-    - path: _test\.go
-      linters:
-        - revive
-      text: "dot-imports:"
-    # If we have tests in shared test folders, these can be less strictly linted
-    - path: tests/.*_tests\.go
-      linters:
-        - revive
-        - bodyclose
-        - stylecheck

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Docker multi-stage build
 # Use the default platform for the build stage
 # hadolint ignore=DL3029
-FROM --platform=linux/amd64 golang:1.24.4-bookworm AS base
+FROM --platform=linux/amd64 golang:1.25.7-bookworm AS base
 
 ARG GIT_COMMIT=unspecified
 ARG BUILD_IMAGE_ID=unspecified

--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ proxy:
   port: 8080
   prefix: "/_auth/"
   timeout: 30
+  trusted_ips:  # List of trusted upstream proxy CIDRs
+    - "127.0.0.1/32"
+    - "10.0.0.0/16"
 
 upstreams:
   - url: "http://localhost:8081"
@@ -157,6 +160,7 @@ Options:
   -B, --cookie-block string   Cookie block key (encryption key, must be 32 bytes)
   -L, --logo string           Path or URL for login page logo
   -T, --template-dir string   Path to custom login template
+  -t, --trusted-ips strings   Trusted upstream proxy CIDRs (e.g. 127.0.0.1/32,10.0.0.0/16)
   -f, --footer-text string    Footer text for login page
   -v, --version               Print version information
   -h, --help                  Show help message
@@ -171,7 +175,7 @@ Options:
 - [ ] Support for Let's Encrypt automatic certificate management. Integrate lego.
 - [ ] Support for multiple upstream services.
 - [ ] Support for configurable all settings via flags and environmental variables.
-- [ ] Run behind another reverse proxy (X-Forwarded-For support).
+- [x] Run behind another reverse proxy (X-Forwarded-For support via `trusted_ips`).
 
 
 

--- a/config.yaml
+++ b/config.yaml
@@ -3,6 +3,7 @@ proxy:
   port: 8080
   prefix: "/_auth/"
   timeout: 30  # Timeout in seconds
+  # trusted_ips: ["127.0.0.1/32", "10.0.0.0/16"]  # CIDRs of trusted upstream proxies
 
 upstreams:
   - url: "http://nagios_legacy:80/"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arulrajnet/basic-auth-proxy
 
-go 1.24.4
+go 1.25.7
 
 require (
 	github.com/gorilla/mux v1.8.1

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ func main() {
 	pflag.StringP("address", "a", "", "address to listen on")
 	pflag.IntP("port", "p", 0, "port to listen on")
 	pflag.StringP("proxy-prefix", "P", "", "prefix path for the proxy")
+	pflag.BoolP("trust-upstream", "t", false, "trust upstream proxy (preserve X-Forwarded-For and X-Real-IP)")
 	pflag.StringP("upstream", "u", "", "upstream server URL")
 	pflag.StringP("cookie-name", "s", "", "cookie name")
 	pflag.StringP("cookie-secret", "S", "", "cookie secret key")

--- a/main.go
+++ b/main.go
@@ -87,8 +87,6 @@ func main() {
 	r.Use(proxy.RequestLogger(logger))
 
 	// Add auth routes
-	// Auth routes (these bypass session middleware check)
-	// r.PathPrefix(authPrefix + "/").Handler(proxyHandler)
 	r.PathPrefix("/").Handler(proxyHandler)
 
 	// Create server

--- a/main.go
+++ b/main.go
@@ -1,3 +1,4 @@
+// Package main is the entry point for the basic-auth-proxy.
 package main
 
 import (
@@ -6,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"runtime"
-	"strings"
 	"time"
 
 	log "github.com/arulrajnet/basic-auth-proxy/pkg/logger"
@@ -87,12 +87,6 @@ func main() {
 	r.Use(proxy.RequestLogger(logger))
 
 	// Add auth routes
-	authPrefix := cfg.Proxy.ProxyPrefix
-	if authPrefix == "" {
-		authPrefix = "/auth"
-	}
-	authPrefix = strings.TrimSuffix(authPrefix, "/")
-
 	// Auth routes (these bypass session middleware check)
 	// r.PathPrefix(authPrefix + "/").Handler(proxyHandler)
 	r.PathPrefix("/").Handler(proxyHandler)

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func main() {
 	pflag.StringP("address", "a", "", "address to listen on")
 	pflag.IntP("port", "p", 0, "port to listen on")
 	pflag.StringP("proxy-prefix", "P", "", "prefix path for the proxy")
-	pflag.BoolP("trust-upstream", "t", false, "trust upstream proxy (preserve X-Forwarded-For and X-Real-IP)")
+	pflag.StringSliceP("trusted-ips", "t", []string{}, "list of trusted upstream proxy CIDRs (e.g. 127.0.0.1/32,10.0.0.0/16)")
 	pflag.StringP("upstream", "u", "", "upstream server URL")
 	pflag.StringP("cookie-name", "s", "", "cookie name")
 	pflag.StringP("cookie-secret", "S", "", "cookie secret key")

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,3 +1,4 @@
+// Package logger provides a centralized logging utility.
 package logger
 
 import (

--- a/pkg/proxy/config.go
+++ b/pkg/proxy/config.go
@@ -20,17 +20,18 @@ type Config struct {
 }
 
 type ProxyConfig struct {
-	Address     string `yaml:"address" mapstructure:"address"`
-	Port        int    `yaml:"port" mapstructure:"port"`
-	Timeout     int    `yaml:"timeout" mapstructure:"timeout"` // Timeout in seconds
-	ProxyPrefix string `yaml:"prefix" mapstructure:"prefix"`
+	Address       string `yaml:"address" mapstructure:"address"`
+	Port          int    `yaml:"port" mapstructure:"port"`
+	Timeout       int    `yaml:"timeout" mapstructure:"timeout"` // Timeout in seconds
+	ProxyPrefix   string `yaml:"prefix" mapstructure:"prefix"`
+	TrustUpstream bool   `yaml:"trust_upstream" mapstructure:"trust_upstream"`
 }
 
 // Upstream defines the structure for each upstream service.
 type Upstream struct {
-	URL     *url.URL `yaml:"-" mapstructure:"-"`                        // Parsed URL (not directly unmarshaled)
-	URLStr  string   `yaml:"url" mapstructure:"url"`                    // Raw URL string for unmarshaling
-	Timeout int      `yaml:"timeout" mapstructure:"timeout"`            // Timeout in seconds
+	URL     *url.URL `yaml:"-" mapstructure:"-"`             // Parsed URL (not directly unmarshaled)
+	URLStr  string   `yaml:"url" mapstructure:"url"`         // Raw URL string for unmarshaling
+	Timeout int      `yaml:"timeout" mapstructure:"timeout"` // Timeout in seconds
 }
 
 type CustomPage struct {
@@ -56,10 +57,11 @@ func DefaultConfig() *Config {
 	proxyPrefix := "/auth" // Default proxy prefix
 	return &Config{
 		Proxy: ProxyConfig{
-			Address:     "0.0.0.0",
-			Port:        8080,
-			Timeout:     30,
-			ProxyPrefix: proxyPrefix,
+			Address:       "0.0.0.0",
+			Port:          8080,
+			Timeout:       30,
+			ProxyPrefix:   proxyPrefix,
+			TrustUpstream: false,
 		},
 		Upstreams: []Upstream{
 			{
@@ -131,18 +133,19 @@ func LoadConfig(configFile string) (*Config, error) {
 
 	// Bind pflags LAST (highest priority - overrides everything)
 	if pflag.CommandLine.Parsed() {
-			logger.Debug().Msg("Binding command line flags")
-			v.BindPFlag("proxy.address", pflag.Lookup("address"))
-			v.BindPFlag("proxy.port", pflag.Lookup("port"))
-			v.BindPFlag("proxy.prefix", pflag.Lookup("proxy-prefix"))
-			v.BindPFlag("log_level", pflag.Lookup("log-level"))
-			v.BindPFlag("upstreams.0.url", pflag.Lookup("upstream"))
-			v.BindPFlag("cookie.name", pflag.Lookup("cookie-name"))
-			v.BindPFlag("cookie.secret_key", pflag.Lookup("cookie-secret"))
-			v.BindPFlag("cookie.block_key", pflag.Lookup("cookie-block"))
-			v.BindPFlag("custom_page.logo", pflag.Lookup("logo"))
-			v.BindPFlag("custom_page.template_dir", pflag.Lookup("template-dir"))
-			v.BindPFlag("custom_page.footer_text", pflag.Lookup("footer-text"))
+		logger.Debug().Msg("Binding command line flags")
+		v.BindPFlag("proxy.address", pflag.Lookup("address"))
+		v.BindPFlag("proxy.port", pflag.Lookup("port"))
+		v.BindPFlag("proxy.prefix", pflag.Lookup("proxy-prefix"))
+		v.BindPFlag("proxy.trust_upstream", pflag.Lookup("trust-upstream"))
+		v.BindPFlag("log_level", pflag.Lookup("log-level"))
+		v.BindPFlag("upstreams.0.url", pflag.Lookup("upstream"))
+		v.BindPFlag("cookie.name", pflag.Lookup("cookie-name"))
+		v.BindPFlag("cookie.secret_key", pflag.Lookup("cookie-secret"))
+		v.BindPFlag("cookie.block_key", pflag.Lookup("cookie-block"))
+		v.BindPFlag("custom_page.logo", pflag.Lookup("logo"))
+		v.BindPFlag("custom_page.template_dir", pflag.Lookup("template-dir"))
+		v.BindPFlag("custom_page.footer_text", pflag.Lookup("footer-text"))
 	}
 
 	// Unmarshal config into struct
@@ -171,6 +174,7 @@ func bindEnvs(v *viper.Viper, config *Config) {
 	v.BindEnv("proxy.port", "BAP_PROXY_PORT")
 	v.BindEnv("proxy.timeout", "BAP_PROXY_TIMEOUT")
 	v.BindEnv("proxy.prefix", "BAP_PROXY_PREFIX")
+	v.BindEnv("proxy.trust_upstream", "BAP_PROXY_TRUST_UPSTREAM")
 
 	v.BindEnv("custom_page.logo", "BAP_CUSTOM_PAGE_LOGO")
 	v.BindEnv("custom_page.template_dir", "BAP_CUSTOM_PAGE_TEMPLATE_DIR")

--- a/pkg/proxy/config.go
+++ b/pkg/proxy/config.go
@@ -24,7 +24,7 @@ type ProxyConfig struct {
 	Port          int    `yaml:"port" mapstructure:"port"`
 	Timeout       int    `yaml:"timeout" mapstructure:"timeout"` // Timeout in seconds
 	ProxyPrefix   string `yaml:"prefix" mapstructure:"prefix"`
-	TrustUpstream bool   `yaml:"trust_upstream" mapstructure:"trust_upstream"`
+	TrustUpstream bool   `yaml:"trust-upstream" mapstructure:"trust-upstream"`
 }
 
 // Upstream defines the structure for each upstream service.

--- a/pkg/proxy/config.go
+++ b/pkg/proxy/config.go
@@ -20,11 +20,11 @@ type Config struct {
 }
 
 type ProxyConfig struct {
-	Address       string `yaml:"address" mapstructure:"address"`
-	Port          int    `yaml:"port" mapstructure:"port"`
-	Timeout       int    `yaml:"timeout" mapstructure:"timeout"` // Timeout in seconds
-	ProxyPrefix   string `yaml:"prefix" mapstructure:"prefix"`
-	TrustUpstream bool   `yaml:"trust_upstream" mapstructure:"trust_upstream"`
+	Address     string   `yaml:"address" mapstructure:"address"`
+	Port        int      `yaml:"port" mapstructure:"port"`
+	Timeout     int      `yaml:"timeout" mapstructure:"timeout"` // Timeout in seconds
+	ProxyPrefix string   `yaml:"prefix" mapstructure:"prefix"`
+	TrustedIPs  []string `yaml:"trusted_ips" mapstructure:"trusted_ips"`
 }
 
 // Upstream defines the structure for each upstream service.
@@ -57,11 +57,11 @@ func DefaultConfig() *Config {
 	proxyPrefix := "/auth" // Default proxy prefix
 	return &Config{
 		Proxy: ProxyConfig{
-			Address:       "0.0.0.0",
-			Port:          8080,
-			Timeout:       30,
-			ProxyPrefix:   proxyPrefix,
-			TrustUpstream: false,
+			Address:     "0.0.0.0",
+			Port:        8080,
+			Timeout:     30,
+			ProxyPrefix: proxyPrefix,
+			TrustedIPs:  []string{},
 		},
 		Upstreams: []Upstream{
 			{
@@ -137,7 +137,7 @@ func LoadConfig(configFile string) (*Config, error) {
 		v.BindPFlag("proxy.address", pflag.Lookup("address"))
 		v.BindPFlag("proxy.port", pflag.Lookup("port"))
 		v.BindPFlag("proxy.prefix", pflag.Lookup("proxy-prefix"))
-		v.BindPFlag("proxy.trust_upstream", pflag.Lookup("trust-upstream"))
+		v.BindPFlag("proxy.trusted_ips", pflag.Lookup("trusted-ips"))
 		v.BindPFlag("log_level", pflag.Lookup("log-level"))
 		v.BindPFlag("upstreams.0.url", pflag.Lookup("upstream"))
 		v.BindPFlag("cookie.name", pflag.Lookup("cookie-name"))
@@ -174,7 +174,7 @@ func bindEnvs(v *viper.Viper, config *Config) {
 	v.BindEnv("proxy.port", "BAP_PROXY_PORT")
 	v.BindEnv("proxy.timeout", "BAP_PROXY_TIMEOUT")
 	v.BindEnv("proxy.prefix", "BAP_PROXY_PREFIX")
-	v.BindEnv("proxy.trust_upstream", "BAP_PROXY_TRUST_UPSTREAM")
+	v.BindEnv("proxy.trusted_ips", "BAP_PROXY_TRUSTED_IPS")
 
 	v.BindEnv("custom_page.logo", "BAP_CUSTOM_PAGE_LOGO")
 	v.BindEnv("custom_page.template_dir", "BAP_CUSTOM_PAGE_TEMPLATE_DIR")

--- a/pkg/proxy/config.go
+++ b/pkg/proxy/config.go
@@ -19,7 +19,8 @@ type Config struct {
 	Cookie     CookieConfig `yaml:"cookie" mapstructure:"cookie"`
 }
 
-type ProxyConfig struct {
+// ProxyConfig holds the configuration for the proxy server.
+type ProxyConfig struct { //nolint:revive
 	Address     string   `yaml:"address" mapstructure:"address"`
 	Port        int      `yaml:"port" mapstructure:"port"`
 	Timeout     int      `yaml:"timeout" mapstructure:"timeout"` // Timeout in seconds
@@ -34,12 +35,14 @@ type Upstream struct {
 	Timeout int      `yaml:"timeout" mapstructure:"timeout"` // Timeout in seconds
 }
 
+// CustomPage holds the configuration for custom login pages.
 type CustomPage struct {
 	Logo        string `yaml:"logo" mapstructure:"logo"`
 	TemplateDir string `yaml:"template_dir" mapstructure:"template_dir"`
 	FooterText  string `yaml:"footer_text" mapstructure:"footer_text"`
 }
 
+// CookieConfig holds the configuration for sessions and cookies.
 type CookieConfig struct {
 	Name      string `yaml:"name" mapstructure:"name"`
 	SecretKey string `yaml:"secret_key" mapstructure:"secret_key"`
@@ -47,7 +50,7 @@ type CookieConfig struct {
 	Domain    string `yaml:"domain" mapstructure:"domain"`
 	Path      string `yaml:"path" mapstructure:"path"`
 	Secure    bool   `yaml:"secure" mapstructure:"secure"`
-	HttpOnly  bool   `yaml:"http_only" mapstructure:"http_only"`
+	HTTPOnly  bool   `yaml:"http_only" mapstructure:"http_only"`
 	MaxAge    int    `yaml:"max_age" mapstructure:"max_age"`
 	SameSite  string `yaml:"same_site" mapstructure:"same_site"`
 }
@@ -79,7 +82,7 @@ func DefaultConfig() *Config {
 			Domain:   "",
 			Path:     "/",
 			Secure:   false,
-			HttpOnly: true,
+			HTTPOnly: true,
 			MaxAge:   86400,
 			SameSite: "lax",
 		},
@@ -134,18 +137,18 @@ func LoadConfig(configFile string) (*Config, error) {
 	// Bind pflags LAST (highest priority - overrides everything)
 	if pflag.CommandLine.Parsed() {
 		logger.Debug().Msg("Binding command line flags")
-		v.BindPFlag("proxy.address", pflag.Lookup("address"))
-		v.BindPFlag("proxy.port", pflag.Lookup("port"))
-		v.BindPFlag("proxy.prefix", pflag.Lookup("proxy-prefix"))
-		v.BindPFlag("proxy.trusted_ips", pflag.Lookup("trusted-ips"))
-		v.BindPFlag("log_level", pflag.Lookup("log-level"))
-		v.BindPFlag("upstreams.0.url", pflag.Lookup("upstream"))
-		v.BindPFlag("cookie.name", pflag.Lookup("cookie-name"))
-		v.BindPFlag("cookie.secret_key", pflag.Lookup("cookie-secret"))
-		v.BindPFlag("cookie.block_key", pflag.Lookup("cookie-block"))
-		v.BindPFlag("custom_page.logo", pflag.Lookup("logo"))
-		v.BindPFlag("custom_page.template_dir", pflag.Lookup("template-dir"))
-		v.BindPFlag("custom_page.footer_text", pflag.Lookup("footer-text"))
+		_ = v.BindPFlag("proxy.address", pflag.Lookup("address"))
+		_ = v.BindPFlag("proxy.port", pflag.Lookup("port"))
+		_ = v.BindPFlag("proxy.prefix", pflag.Lookup("proxy-prefix"))
+		_ = v.BindPFlag("proxy.trusted_ips", pflag.Lookup("trusted-ips"))
+		_ = v.BindPFlag("log_level", pflag.Lookup("log-level"))
+		_ = v.BindPFlag("upstreams.0.url", pflag.Lookup("upstream"))
+		_ = v.BindPFlag("cookie.name", pflag.Lookup("cookie-name"))
+		_ = v.BindPFlag("cookie.secret_key", pflag.Lookup("cookie-secret"))
+		_ = v.BindPFlag("cookie.block_key", pflag.Lookup("cookie-block"))
+		_ = v.BindPFlag("custom_page.logo", pflag.Lookup("logo"))
+		_ = v.BindPFlag("custom_page.template_dir", pflag.Lookup("template-dir"))
+		_ = v.BindPFlag("custom_page.footer_text", pflag.Lookup("footer-text"))
 	}
 
 	// Unmarshal config into struct
@@ -169,32 +172,32 @@ func LoadConfig(configFile string) (*Config, error) {
 }
 
 // bindEnvs recursively binds all nested config struct fields to environment variables
-func bindEnvs(v *viper.Viper, config *Config) {
-	v.BindEnv("proxy.address", "BAP_PROXY_ADDRESS")
-	v.BindEnv("proxy.port", "BAP_PROXY_PORT")
-	v.BindEnv("proxy.timeout", "BAP_PROXY_TIMEOUT")
-	v.BindEnv("proxy.prefix", "BAP_PROXY_PREFIX")
-	v.BindEnv("proxy.trusted_ips", "BAP_PROXY_TRUSTED_IPS")
+func bindEnvs(v *viper.Viper, _ *Config) {
+	_ = v.BindEnv("proxy.address", "BAP_PROXY_ADDRESS")
+	_ = v.BindEnv("proxy.port", "BAP_PROXY_PORT")
+	_ = v.BindEnv("proxy.timeout", "BAP_PROXY_TIMEOUT")
+	_ = v.BindEnv("proxy.prefix", "BAP_PROXY_PREFIX")
+	_ = v.BindEnv("proxy.trusted_ips", "BAP_PROXY_TRUSTED_IPS")
 
-	v.BindEnv("custom_page.logo", "BAP_CUSTOM_PAGE_LOGO")
-	v.BindEnv("custom_page.template_dir", "BAP_CUSTOM_PAGE_TEMPLATE_DIR")
-	v.BindEnv("custom_page.footer_text", "BAP_CUSTOM_PAGE_FOOTER_TEXT")
+	_ = v.BindEnv("custom_page.logo", "BAP_CUSTOM_PAGE_LOGO")
+	_ = v.BindEnv("custom_page.template_dir", "BAP_CUSTOM_PAGE_TEMPLATE_DIR")
+	_ = v.BindEnv("custom_page.footer_text", "BAP_CUSTOM_PAGE_FOOTER_TEXT")
 
-	v.BindEnv("log_level", "BAP_LOG_LEVEL")
+	_ = v.BindEnv("log_level", "BAP_LOG_LEVEL")
 
-	v.BindEnv("cookie.name", "BAP_COOKIE_NAME")
-	v.BindEnv("cookie.secret_key", "BAP_COOKIE_SECRET_KEY")
-	v.BindEnv("cookie.block_key", "BAP_COOKIE_BLOCK_KEY")
-	v.BindEnv("cookie.domain", "BAP_COOKIE_DOMAIN")
-	v.BindEnv("cookie.path", "BAP_COOKIE_PATH")
-	v.BindEnv("cookie.secure", "BAP_COOKIE_SECURE")
-	v.BindEnv("cookie.http_only", "BAP_COOKIE_HTTP_ONLY")
-	v.BindEnv("cookie.max_age", "BAP_COOKIE_MAX_AGE")
-	v.BindEnv("cookie.same_site", "BAP_COOKIE_SAME_SITE")
+	_ = v.BindEnv("cookie.name", "BAP_COOKIE_NAME")
+	_ = v.BindEnv("cookie.secret_key", "BAP_COOKIE_SECRET_KEY")
+	_ = v.BindEnv("cookie.block_key", "BAP_COOKIE_BLOCK_KEY")
+	_ = v.BindEnv("cookie.domain", "BAP_COOKIE_DOMAIN")
+	_ = v.BindEnv("cookie.path", "BAP_COOKIE_PATH")
+	_ = v.BindEnv("cookie.secure", "BAP_COOKIE_SECURE")
+	_ = v.BindEnv("cookie.http_only", "BAP_COOKIE_HTTP_ONLY")
+	_ = v.BindEnv("cookie.max_age", "BAP_COOKIE_MAX_AGE")
+	_ = v.BindEnv("cookie.same_site", "BAP_COOKIE_SAME_SITE")
 
 	// Bind upstreams as strings to be processed later
-	v.BindEnv("upstreams.0.url", "BAP_UPSTREAM_URL")
-	v.BindEnv("upstreams.0.timeout", "BAP_UPSTREAM_TIMEOUT")
+	_ = v.BindEnv("upstreams.0.url", "BAP_UPSTREAM_URL")
+	_ = v.BindEnv("upstreams.0.timeout", "BAP_UPSTREAM_TIMEOUT")
 }
 
 // processURLs handles parsing of URL strings from config and environment variables

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -224,7 +224,8 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // Handle sign-in requests (both GET for form and POST for credentials)
 func (p *Proxy) handleSignIn(w http.ResponseWriter, r *http.Request) {
-	if r.Method == http.MethodGet {
+	switch r.Method {
+	case http.MethodGet:
 		// Check if user is already authenticated
 		if userInfo, err := p.sessionManager.GetUserInfo(r, p.config.Cookie.Name); err == nil && userInfo != nil {
 			// User is already logged in, redirect to root
@@ -236,7 +237,7 @@ func (p *Proxy) handleSignIn(w http.ResponseWriter, r *http.Request) {
 		// Serve the login page
 		p.serveLoginPage(w, r)
 		return
-	} else if r.Method == http.MethodPost {
+	case http.MethodPost:
 		// Process login form
 		err := r.ParseForm()
 		if err != nil {
@@ -288,7 +289,7 @@ func (p *Proxy) handleSignIn(w http.ResponseWriter, r *http.Request) {
 		}
 
 		http.Redirect(w, r, redirectPath, http.StatusFound)
-	} else {
+	default:
 		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
 	}
 }

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -118,9 +118,18 @@ func TestProxyTrustedIPs(t *testing.T) {
 
 			// Verification
 			if tt.shouldTrust {
-				// Trusted: preserved
-				if gotXFF != tt.xffIncoming {
-					t.Errorf("Trusted: expected XFF %q, got %q", tt.xffIncoming, gotXFF)
+				// Trusted: XFF should include the original header plus the client IP host
+				clientIPNoPort := tt.clientIP
+				if host, _, err := net.SplitHostPort(tt.clientIP); err == nil {
+					clientIPNoPort = host
+				}
+				expectedXFFTrusted := clientIPNoPort
+				if tt.xffIncoming != "" {
+					expectedXFFTrusted = tt.xffIncoming + ", " + clientIPNoPort
+				}
+
+				if gotXFF != expectedXFFTrusted {
+					t.Errorf("Trusted: expected XFF %q, got %q", expectedXFFTrusted, gotXFF)
 				}
 				if gotRealIP != tt.realIPIncoming {
 					t.Errorf("Trusted: expected RealIP %q, got %q", tt.realIPIncoming, gotRealIP)

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -1,0 +1,135 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/arulrajnet/basic-auth-proxy/pkg/session"
+)
+
+func TestProxyTrustUpstream(t *testing.T) {
+	// 1. Mock Backend
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Received-Forwarded-For", r.Header.Get("X-Forwarded-For"))
+		w.Header().Set("X-Received-Real-IP", r.Header.Get("X-Real-IP"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	backendURL, _ := url.Parse(backend.URL)
+
+	tests := []struct {
+		name           string
+		trustUpstream  bool
+		clientIP       string
+		xffIncoming    string
+		realIPIncoming string
+		protoIncoming  string
+		portIncoming   string
+		expectRealIP   string
+		expectProto    string
+		expectPort     string
+	}{
+		{
+			name:           "Untrusted (Default): Should overwrite X-Real-IP and sanitize XFF/Proto/Port",
+			trustUpstream:  false,
+			clientIP:       "1.2.3.4:12345",
+			xffIncoming:    "100.100.100.100",
+			realIPIncoming: "100.100.100.100",
+			protoIncoming:  "https",
+			portIncoming:   "443",
+			expectRealIP:   "1.2.3.4:12345", // overwritten to RemoteAddr
+			expectProto:    "",              // Deleted
+			expectPort:     "",              // Deleted
+		},
+		{
+			name:           "Trusted: Should preserve XFF and X-Real-IP and Proto/Port",
+			trustUpstream:  true,
+			clientIP:       "1.2.3.4:12345",
+			xffIncoming:    "100.100.100.100",
+			realIPIncoming: "100.100.100.100",
+			protoIncoming:  "https",
+			portIncoming:   "443",
+			expectRealIP:   "100.100.100.100",
+			expectProto:    "https",
+			expectPort:     "443",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Config
+			cfg := &Config{
+				Proxy: ProxyConfig{
+					TrustUpstream: tt.trustUpstream,
+					ProxyPrefix:   "/",
+				},
+				Upstreams: []Upstream{{URL: backendURL}},
+				Cookie: CookieConfig{
+					Name: "test_cookie",
+				},
+			}
+
+			// Session Mock
+			sm := session.NewSessionManager("12345678901234567890123456789012", "12345678901234567890123456789012") // 32 bytes
+
+			// Create Proxy
+			p := NewProxy(cfg, sm)
+
+			// Setup request
+			req := httptest.NewRequest("GET", "http://proxy/", nil)
+			req.RemoteAddr = tt.clientIP
+			req.Header.Set("X-Forwarded-For", tt.xffIncoming)
+			req.Header.Set("X-Real-IP", tt.realIPIncoming)
+			req.Header.Set("X-Forwarded-Proto", tt.protoIncoming)
+			req.Header.Set("X-Forwarded-Port", tt.portIncoming)
+
+			// Check if reverseProxy is initialized
+			if p.reverseProxy == nil {
+				t.Fatal("ReverseProxy is nil")
+			}
+
+			// Invoke Director directly
+			p.reverseProxy.Director(req)
+
+			// Check Headers
+			gotXFF := req.Header.Get("X-Forwarded-For")
+			gotRealIP := req.Header.Get("X-Real-IP")
+			gotProto := req.Header.Get("X-Forwarded-Proto")
+			gotPort := req.Header.Get("X-Forwarded-Port")
+
+			// Verification
+			if tt.trustUpstream {
+				// Trusted: preserved
+				if gotXFF != tt.xffIncoming {
+					t.Errorf("Trusted: expected XFF %q, got %q", tt.xffIncoming, gotXFF)
+				}
+				if gotRealIP != tt.realIPIncoming {
+					t.Errorf("Trusted: expected RealIP %q, got %q", tt.realIPIncoming, gotRealIP)
+				}
+				if gotProto != tt.protoIncoming {
+					t.Errorf("Trusted: expected Proto %q, got %q", tt.protoIncoming, gotProto)
+				}
+				if gotPort != tt.portIncoming {
+					t.Errorf("Trusted: expected Port %q, got %q", tt.portIncoming, gotPort)
+				}
+			} else {
+				// Untrusted: sanitized
+				if gotXFF != "" {
+					t.Errorf("Untrusted: expected empty XFF (deleted), got %q", gotXFF)
+				}
+				if gotRealIP != tt.clientIP {
+					t.Errorf("Untrusted: expected RealIP %q, got %q", tt.clientIP, gotRealIP)
+				}
+				if gotProto != tt.expectProto {
+					t.Errorf("Untrusted: expected Proto %q, got %q", tt.expectProto, gotProto)
+				}
+				if gotPort != tt.expectPort {
+					t.Errorf("Untrusted: expected Port %q, got %q", tt.expectPort, gotPort)
+				}
+			}
+		})
+	}
+}

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -118,18 +118,9 @@ func TestProxyTrustedIPs(t *testing.T) {
 
 			// Verification
 			if tt.shouldTrust {
-				// Trusted: XFF should include the original header plus the client IP host
-				clientIPNoPort := tt.clientIP
-				if host, _, err := net.SplitHostPort(tt.clientIP); err == nil {
-					clientIPNoPort = host
-				}
-				expectedXFFTrusted := clientIPNoPort
-				if tt.xffIncoming != "" {
-					expectedXFFTrusted = tt.xffIncoming + ", " + clientIPNoPort
-				}
-
-				if gotXFF != expectedXFFTrusted {
-					t.Errorf("Trusted: expected XFF %q, got %q", expectedXFFTrusted, gotXFF)
+				// Trusted: preserved
+				if gotXFF != tt.xffIncoming {
+					t.Errorf("Trusted: expected XFF %q, got %q", tt.xffIncoming, gotXFF)
 				}
 				if gotRealIP != tt.realIPIncoming {
 					t.Errorf("Trusted: expected RealIP %q, got %q", tt.realIPIncoming, gotRealIP)

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestProxyTrustedIPs(t *testing.T) {
 	// 1. Mock Backend
-	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer backend.Close()

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -74,7 +74,7 @@ func NewSessionManager(secretKey, blockKey string) *SessionManager {
 func (m *SessionManager) ConfigureCookie(name, path, domain string, maxAge int, secure, httpOnly bool, sameSite string) {
 	m.cookieName = name
 	m.cookiePath = path
-	if domain != "localhost" || domain != "127.0.0.1" {
+	if domain != "localhost" && domain != "127.0.0.1" {
 		m.cookieDomain = domain
 	} else {
 		m.cookieDomain = ""

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -1,3 +1,4 @@
+// Package session provides session management using gorilla sessions.
 package session
 
 import (
@@ -15,7 +16,8 @@ import (
 
 var logger = log.GetLogger()
 
-type SessionManager struct {
+// SessionManager handles session storage and retrieval.
+type SessionManager struct { //nolint:revive
 	store        *sessions.CookieStore
 	cookieName   string
 	cookiePath   string
@@ -26,12 +28,14 @@ type SessionManager struct {
 	sameSite     http.SameSite
 }
 
+// UserInfo contains authenticated user data.
 type UserInfo struct {
 	Username string    `json:"username"`
 	Password string    `json:"password"`
 	LoggedIn time.Time `json:"logged_in"`
 }
 
+// NewSessionManager creates a new session manager with the given keys.
 func NewSessionManager(secretKey, blockKey string) *SessionManager {
 	// Create hash key (for signing)
 	hashKey := []byte(secretKey)
@@ -106,15 +110,18 @@ func (m *SessionManager) ConfigureCookie(name, path, domain string, maxAge int, 
 	}
 }
 
+// Get retrieves a session from the store.
 func (m *SessionManager) Get(r *http.Request, name string) (*sessions.Session, error) {
 	return m.store.Get(r, name)
 }
 
+// GenerateBasicAuth generates a Basic Auth header from username and password.
 func (m *SessionManager) GenerateBasicAuth(username, password string) string {
 	auth := username + ":" + password
 	return "Basic " + base64.StdEncoding.EncodeToString([]byte(auth))
 }
 
+// CreateUserSession creates a new session for the user.
 func (m *SessionManager) CreateUserSession(w http.ResponseWriter, r *http.Request, sessionName, username, password string) error {
 	// Get session
 	session, err := m.Get(r, sessionName)
@@ -132,6 +139,7 @@ func (m *SessionManager) CreateUserSession(w http.ResponseWriter, r *http.Reques
 	return session.Save(r, w)
 }
 
+// GetUserInfo retrieves UserInfo from the session.
 func (m *SessionManager) GetUserInfo(r *http.Request, sessionName string) (*UserInfo, error) {
 	session, err := m.Get(r, sessionName)
 	if err != nil {
@@ -174,6 +182,7 @@ func (m *SessionManager) GetUserInfo(r *http.Request, sessionName string) (*User
 	}, nil
 }
 
+// Destroy destroys the session.
 func (m *SessionManager) Destroy(w http.ResponseWriter, r *http.Request, name string) error {
 	session, err := m.Get(r, name)
 	if err != nil {

--- a/pkg/templates/login.go
+++ b/pkg/templates/login.go
@@ -1,11 +1,16 @@
+// Package templates contains HTML templates for the login page.
 package templates
 
 import (
 	_ "embed"
 )
 
+// LoginTemplate is the HTML template for the login page.
+//
 //go:embed login.html
 var LoginTemplate string
 
+// ErrorTemplate is the HTML template for the error page.
+//
 //go:embed error.html
 var ErrorTemplate string

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,4 @@
+// Package version contains the version information for the application.
 package version
 
 // VERSION contains version information


### PR DESCRIPTION
added new comma-separader list of CIDRs property `proxy.trusted-ips` or `BAP_PROXY_TRUSTED_IPS` or `-t` if the proxy is between proxies to propagate them to the backend. Default value to "" (empty). The headers are propagaded only if the last ip (remoteip) complies with one of the valid CIDRs. The headers propagated:
- *X-Forwarded-For*: (add the current proxy ip as a list, real-client-ip, proxy-1, proxy-2...)
- *X-Forwarded-Proto*: (http or https, normally propagated "as is")
- *X-Forwarded-Port*: (443, 80, or other, propagated "as is")
- *X-Real-IP*: (client-ip, propagated "as-is")