### PR TITLE
fix(security): upgrade Go to 1.25.8 and resolve gosec findings

### DIFF
--- a/.github/workflows/docker-security.yml
+++ b/.github/workflows/docker-security.yml
@@ -22,6 +22,7 @@ env:
 jobs:
   dockerfile-lint:
     runs-on: ubuntu-latest
+    if: github.event_name != 'schedule' || github.event.repository.fork == false
     permissions:
       contents: read
       security-events: write
@@ -45,6 +46,7 @@ jobs:
 
   security-scan:
     runs-on: ubuntu-latest
+    if: github.event_name != 'schedule' || github.event.repository.fork == false
     permissions:
       contents: read
       security-events: write
@@ -107,6 +109,7 @@ jobs:
 
   best-practices:
     runs-on: ubuntu-latest
+    if: github.event_name != 'schedule' || github.event.repository.fork == false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -177,7 +180,7 @@ jobs:
 
   image-analysis:
     runs-on: ubuntu-latest
-    if: github.event_name != 'schedule'
+    if: github.event_name != 'schedule' || github.event.repository.fork == false
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/pr-comment-on-fork.yml
+++ b/.github/workflows/pr-comment-on-fork.yml
@@ -1,3 +1,5 @@
+name: Comment on Fork PRs
+
 on:
   pull_request_target:  # Instead of pull_request
     types: [opened]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Docker multi-stage build
 # Use the default platform for the build stage
 # hadolint ignore=DL3029
-FROM --platform=linux/amd64 golang:1.25.7-bookworm AS base
+FROM --platform=linux/amd64 golang:1.25.8-bookworm AS base
 
 ARG GIT_COMMIT=unspecified
 ARG BUILD_IMAGE_ID=unspecified

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GOCLEAN=$(GOCMD) clean
 GOTEST=$(GOCMD) test
 GOGET=$(GOCMD) get
 GOMOD=$(GOCMD) mod
-GOLINT=golangci-lint
+GOLINT=$(shell go env GOPATH)/bin/golangci-lint
 
 # Binary name
 BINARY_NAME=basic-auth-proxy

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/arulrajnet/basic-auth-proxy
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/gorilla/mux v1.8.1

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -3,6 +3,7 @@ package proxy
 
 import (
 	"embed"
+	"encoding/json"
 	"fmt"
 	"html/template"
 	"io/fs"
@@ -234,6 +235,7 @@ func (p *Proxy) handleSignIn(w http.ResponseWriter, r *http.Request) {
 		return
 	case http.MethodPost:
 		// Process login form
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1 MB limit to prevent memory exhaustion
 		err := r.ParseForm()
 		if err != nil {
 			logger.Error().Err(err).Msg("Failed to parse login form")
@@ -322,18 +324,26 @@ func (p *Proxy) handleSignOut(w http.ResponseWriter, r *http.Request) {
 
 // Handle user_info requests
 func (p *Proxy) handleUserInfo(w http.ResponseWriter, r *http.Request) {
-	// Get user info from session
-	userInfoJSON, err := p.sessionManager.GetUserInfoJSON(r, p.config.Cookie.Name)
+	userInfo, err := p.sessionManager.GetUserInfo(r, p.config.Cookie.Name)
 	if err != nil {
 		logger.Error().Err(err).Msg("Failed to get user info")
 		http.Error(w, "Not Authenticated", http.StatusUnauthorized)
 		return
 	}
 
-	// Return user info as JSON
-	w.Header().Set("Content-Type", "application/json")
+	response := struct {
+		Username string    `json:"username"`
+		LoggedIn time.Time `json:"logged_in"`
+	}{
+		Username: userInfo.Username,
+		LoggedIn: userInfo.LoggedIn,
+	}
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write(userInfoJSON)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		logger.Error().Err(err).Msg("Failed to encode user info response")
+	}
 }
 
 // Serve the login page

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -4,7 +4,6 @@ package session
 import (
 	"crypto/sha256"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -194,21 +193,3 @@ func (m *SessionManager) Destroy(w http.ResponseWriter, r *http.Request, name st
 	return session.Save(r, w)
 }
 
-// GetUserInfoJSON returns user info as JSON
-func (m *SessionManager) GetUserInfoJSON(r *http.Request, sessionName string) ([]byte, error) {
-	userInfo, err := m.GetUserInfo(r, sessionName)
-	if err != nil {
-		return nil, err
-	}
-
-	// Create a response object without the password field
-	userResponse := struct {
-		Username string    `json:"username"`
-		LoggedIn time.Time `json:"logged_in"`
-	}{
-		Username: userInfo.Username,
-		LoggedIn: userInfo.LoggedIn,
-	}
-
-	return json.Marshal(userResponse)
-}


### PR DESCRIPTION
- Bump go directive and Dockerfile base image 1.25.7 -> 1.25.8 to fix CVE-2026-25679 (net/url incorrect IPv6 host literal parsing, HIGH)
- Add http.MaxBytesReader before r.ParseForm() to cap login form body at 1 MB, preventing memory exhaustion (gosec G120)
- Replace w.Write([]byte) with json.NewEncoder in handleUserInfo to eliminate taint path flagged by gosec G705
- Guard all scheduled jobs in docker-security.yml with fork check so scheduled scans don't consume build minutes on forked repos
- Use $(go env GOPATH)/bin/golangci-lint in Makefile to resolve binary not found when GOPATH/bin is not in PATH